### PR TITLE
prefer pagination links

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,3 +50,4 @@ Useful options to tweak (add to the above command via ``-s NAME=value``):
 - ``AUTOLOGIN_ENABLED`` - set to 0 to disable autologin middleware
 - ``DOWNLOAD_DELAY`` - set to 0 when crawling local test server
 - ``RUN_HH`` - set to 0 to skip running full headless-horesman scripts
+- ``PREFER_PAGINATION`` - set to 0 to disable pagination handling

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 Scrapy==1.1.0rc3
 -e git+git@github.com:lopuhin/scrapy-splash.git@hh#egg=scrapyjs
 Formasaurus[with-deps]==0.7.1
+autopager==0.1

--- a/undercrawler/items.py
+++ b/undercrawler/items.py
@@ -4,9 +4,15 @@ import scrapy
 class PageItem(scrapy.Item):
     url = scrapy.Field()
     text = scrapy.Field()
+    is_page = scrapy.Field()
+    depth = scrapy.Field()
 
     def __repr__(self):
-        return repr({'url': self['url']})
+        return repr({
+            'url': self['url'],
+            'is_page': self['is_page'],
+            'depth': self['depth'],
+        })
 
 
 class FormItem(scrapy.Item):

--- a/undercrawler/settings.py
+++ b/undercrawler/settings.py
@@ -12,6 +12,8 @@ SPLASH_URL = 'http://127.0.0.1:8050'
 AUTOLOGIN_URL = 'http://127.0.0.1:8089'
 AUTOLOGIN_ENABLED = True
 
+PREFER_PAGINATION = True
+
 DOWNLOADER_MIDDLEWARES = {
     'undercrawler.middleware.AutologinMiddleware': 584,
 }

--- a/undercrawler/spiders/base_spider.py
+++ b/undercrawler/spiders/base_spider.py
@@ -1,8 +1,12 @@
 import re
+import contextlib
 
+import autopager
 import formasaurus
 import scrapy
 from scrapy.linkextractors import LinkExtractor
+from scrapy.utils.url import canonicalize_url
+from scrapy.utils.python import unique
 
 from ..items import PageItem, FormItem
 
@@ -32,11 +36,29 @@ class BaseSpider(scrapy.Spider):
     def parse(self, response):
         url = response.url
         self.logger.info(url)
-        yield PageItem(url=url, text=response.text)
+        yield PageItem(
+            url=url,
+            text=response.text,
+            is_page=response.meta.get('is_page', False),
+            depth=response.meta.get('depth', None),
+            )
         if response.text:
             for _, meta in formasaurus.extract_forms(response.text):
                 yield FormItem(url=url, form_type=meta['form'])
                 self.logger.info('Found a %s form at %s', meta['form'], url)
+
+        if self.settings.getbool('PREFER_PAGINATION'):
+            # Follow pagination links; pagination is not a subject of
+            # a max depth limit. This also prioritizes pagination links because
+            # depth is not increased for them.
+            with _dont_increase_depth(response):
+                for url in self._pagination_urls(response):
+                    # self.logger.debug('Pagination link found: %s', url)
+                    yield self.splash_request(url, meta={'is_page': True})
+
+        # Follow all in-domain links.
+        # Pagination requests are sent twice, but we don't care because
+        # they're be filtered out by a dupefilter.
         for link in self.link_extractor.extract_links(response):
             yield self.splash_request(link.url)
 
@@ -48,3 +70,20 @@ class BaseSpider(scrapy.Spider):
     def _start_url_re(self, url):
         http_www = r'^https?://(www\.)?'
         return re.compile(http_www + re.sub(http_www, '', url), re.I)
+
+    def _pagination_urls(self, response):
+        return [
+            url for url in
+            unique(canonicalize_url(url) for url in autopager.urls(response))
+            if url.startswith('http')
+        ]
+
+
+@contextlib.contextmanager
+def _dont_increase_depth(response):
+    # XXX: a hack to keep the same depth for outgoing requests
+    response.meta['depth'] -= 1
+    try:
+        yield
+    finally:
+        response.meta['depth'] += 1


### PR DESCRIPTION
I've added an option not to increase depth for pagination links. Because we crawl BFS this means these links are also prioritized. 

No depth limit at all is bad because pagination detection is not perfect (e.g. crawler may get stuck in a calendar which look similar to paginator). So it could make sense to add another depth limit middleware which will use its own 'pagination depth' as a stopping criteria. But there can be thousands of pages; the limit should be large (10K?). I haven't added it in this PR. Anyways, for crawler evaluation we have a (soft) time limit which is relatively short; because of that the absence of 'pagination depth' limit shouldn't affect results much.
