### PR TITLE
Export in CDRv2 format

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,5 +51,4 @@ Useful options to tweak (add to the above command via ``-s NAME=value``):
 - ``DOWNLOAD_DELAY`` - set to 0 when crawling local test server
 - ``RUN_HH`` - set to 0 to skip running full headless-horesman scripts
 - ``PREFER_PAGINATION`` - set to 0 to disable pagination handling
-- ``CDR_EXPORT`` - set to 0 to disable export in CDR format
-- ``CDR_*`` - CDR export constants
+- ``CDR_CRAWLER``, ``CDR_TEAM`` - CDR export metadata constants

--- a/undercrawler/items.py
+++ b/undercrawler/items.py
@@ -1,20 +1,6 @@
 import scrapy
 
 
-class PageItem(scrapy.Item):
-    url = scrapy.Field()
-    text = scrapy.Field()
-    is_page = scrapy.Field()
-    depth = scrapy.Field()
-
-    def __repr__(self):
-        return repr({
-            'url': self['url'],
-            'is_page': self['is_page'],
-            'depth': self['depth'],
-        })
-
-
 class CDRItem(scrapy.Item):
 
     # (url)-(crawl timestamp), SHA-256 hashed, UPPERCASE (string)
@@ -27,6 +13,10 @@ class CDRItem(scrapy.Item):
     crawler = scrapy.Field()
 
     # Tika/other extraction output (object)
+    # Our suff here:
+    #  forms: forms metadata as extracted by formasaurus
+    #  depth: page depth
+    #  is_page: this is a page reached by pagination
     extracted_metadata = scrapy.Field()
 
     # Tika/other extraction output (string)
@@ -49,5 +39,6 @@ class CDRItem(scrapy.Item):
     version = scrapy.Field()
 
     def __repr__(self):
-        fields = ['_id', 'url', 'timestamp']
-        return repr({f: self[f] for f in fields})
+        fields = ['_id', 'url', 'timestamp', 'extracted_metadata']
+        return '<CDRItem: {}>'.format(', '.join(
+            '{}: {}'.format(f, repr(self[f])) for f in fields))

--- a/undercrawler/settings.py
+++ b/undercrawler/settings.py
@@ -12,7 +12,6 @@ SPLASH_URL = 'http://127.0.0.1:8050'
 AUTOLOGIN_URL = 'http://127.0.0.1:8089'
 AUTOLOGIN_ENABLED = True
 
-CDR_EXPORT = True
 CDR_CRAWLER = 'scrapy undercrawler'
 CDR_TEAM = 'HG'
 


### PR DESCRIPTION
Also remove export of found forms, and do not save pages from other domains (we can get there after following redirects).

I've included only required field, and left `extracted_metadata` empty. Also, I did not include required `_timestamp` field, since the docs say it should be autogenerated by elasticsearch.
