### PR TITLE
Saving documents in CDR format

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,8 @@ Useful options to tweak (add to the above command via ``-s NAME=value``):
 - ``CDR_CRAWLER``, ``CDR_TEAM`` - CDR export metadata constants
 - ``CRAZY_SEARCH_ENABLED`` - set to 0 to disable submitting search forms
 - ``DOWNLOAD_DELAY`` - set to 0 when crawling local test server
+- ``FILES_STORE`` - S3 location for saving extracted documents
+ (format is ``s3://bucket/prefix/``)
 - ``FORCE_TOR`` - crawl via tor to avoid blocking
 - ``HARD_URL_CONSTRAINT`` - set to 1 to treat start urls as hard constraints
  (by default we start from given url but crawl the whole domain)

--- a/undercrawler/documents_pipeline.py
+++ b/undercrawler/documents_pipeline.py
@@ -1,0 +1,26 @@
+import os.path
+
+from scrapy.http import Request
+from scrapy.pipelines.files import FilesPipeline, S3FilesStore, FSFilesStore
+from scrapy.exceptions import DropItem
+
+
+class CDRDocumentsPipeline(FilesPipeline):
+    def get_media_requests(self, item, info):
+        url = item.get('obj_original_url')
+        return [Request(url)] if url else []
+
+    def item_completed(self, results, item, info):
+        if item.get('obj_original_url'):
+            if len(results) == 1:
+                [(ok, meta)] = results
+                if ok:
+                    if isinstance(self.store, S3FilesStore):
+                        item['obj_stored_url'] = 's3://{}/{}{}'.format(
+                            self.store.bucket, self.store.prefix, meta['path'])
+                    elif isinstance(self.store, FSFilesStore):
+                        item['obj_stored_url'] = os.path.join(
+                            self.store.basedir, meta['path'])
+                    return item
+            raise DropItem
+        return item

--- a/undercrawler/items.py
+++ b/undercrawler/items.py
@@ -18,6 +18,17 @@ class CDRItem(scrapy.Item):
     # Tika/other extraction output (string)
     extracted_text = scrapy.Field()
 
+    # If present, this will contain the _id field of a parent record (string)
+    obj_parent = scrapy.Field()
+
+    # URL reference to a binary object's original location (string)
+    obj_original_url = scrapy.Field()
+
+    # URL reference to a cached copy of a binary object,
+    # suggested format to minimize duplication:
+    # filename is the UPPERCASE hash SHA-256 of the object
+    obj_stored_url = scrapy.Field()
+
     # Original source text/html (string)
     raw_content = scrapy.Field()
 

--- a/undercrawler/settings.py
+++ b/undercrawler/settings.py
@@ -21,6 +21,10 @@ ADBLOCK = False
 MAX_DOMAIN_SEARCH_FORMS = 10
 HARD_URL_CONSTRAINT = False
 
+FILES_STORE_S3_ACL = 'public-read'
+# Set FILES_STORE to enable
+ITEM_PIPELINES = {'undercrawler.documents_pipeline.CDRDocumentsPipeline': 1}
+
 DOWNLOADER_MIDDLEWARES = {
     'undercrawler.middleware.AutologinMiddleware': 584,
 }

--- a/undercrawler/utils.py
+++ b/undercrawler/utils.py
@@ -1,0 +1,10 @@
+def cached_property(name):
+    def deco(fn):
+        def inner(self):
+            cached = getattr(self, name)
+            if cached is None:
+                cached = fn(self)
+                setattr(self, name, cached)
+            return cached
+        return property(inner)
+    return deco


### PR DESCRIPTION
Document links are extracted from page ignoring default extensions blacklist, using `img` tag in addition to `a` and `area`. For each link we create an item with `obj_original_url` field, which is later handled by the `CDRDocumentsPipeline`. In order to make it work, `FILES_STORE` must be set (`s3://bucket/prefix/`).

CDR docs for the `obj_stored_url` field suggest that "URL reference to a cached copy of a binary object, suggested format to minimize duplication: filename is the UPPERCASE hash SHA-256 of the object", but here I use scrapy default of filename url hash + original extension. By default, files pipeline generates the filename before downloading, so it was easier to go with default since this is a suggestion, not a requirement.

I also updated hh_splash middleware to process only requests with "use_hh_splash" in meta, so that files are downloaded without it.
