### PR TITLE
Scrapy-splash cookies, autologin middleware tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,14 @@ services:
 
 before_install:
     - docker run -d -p 8050:8050 scrapinghub/splash
+    # Autologin
+    - pip install -U pip wheel
+    - git clone https://github.com/TeamHG-Memex/autologin.git -b crawler-integration
+    - pip install --trusted-host=ccdd0ebb5a931e58c7c5-aae005c4999d7244ac63632f8b80e089.r77.cf2.rackcdn.com --find-links=http://ccdd0ebb5a931e58c7c5-aae005c4999d7244ac63632f8b80e089.r77.cf2.rackcdn.com numpy scipy scikit-learn
+    - pip install -r autologin/requirements.txt --no-binary Formasaurus
+    - python -c "import formasaurus; formasaurus.extract_forms('a')"
+    - cd autologin && python setup.py install
+    - autologin-http-api &
 
 addons:
     apt:

--- a/README.md
+++ b/README.md
@@ -97,6 +97,9 @@ Useful options to tweak (add to the above command via ``-s NAME=value``):
 - ``RUN_HH`` - set to 0 to skip running full headless-horesman scripts
 - ``SEARCH_TERMS_FILE`` - file with extra search terms to use (one per line)
 - ``SPLASH_URL`` - url of the splash instance
+- ``USERNAME``, ``PASSWORD``, ``LOGIN_URL`` - specify values to pass to
+  autologin - use them if you do not want to use autologin keychain UI.
+  ``LOGIN_URL`` is a relative url.
 
 You can also pass auth cookies explicitly: see ``AutologinMiddleware`` docs.
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 git+https://github.com/scrapy/scrapy.git@288f8c09f8bac4c92f49332c8a5f5a21a182cc15
-git+https://github.com/scrapy-plugins/scrapy-splash.git@b692adb3018141e6510e0174270ccf3787e1f48f
+git+https://github.com/lopuhin/scrapy-splash.git@b213e8eacb6c7e23c6b80e7c2768bd47a51c7243
 Formasaurus[with-deps]==0.7.1
 autopager==0.1
 datasketch==0.1.35

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 git+https://github.com/scrapy/scrapy.git@288f8c09f8bac4c92f49332c8a5f5a21a182cc15
-git+https://github.com/lopuhin/scrapy-splash.git@b213e8eacb6c7e23c6b80e7c2768bd47a51c7243
+git+https://github.com/scrapy-plugins/scrapy-splash.git@7cbb5931c42fd231c4890dc3d1203eb8b7286686
 Formasaurus[with-deps]==0.7.1
 autopager==0.1
 datasketch==0.1.35

--- a/tests/mockserver.py
+++ b/tests/mockserver.py
@@ -11,8 +11,8 @@ class MockServer():
     def __init__(self, resource):
         self.resource = '{}.{}'.format(resource.__module__, resource.__name__)
         self.proc = None
-        self.root_url = 'http://%s:%d' % (
-            socket.gethostbyname(socket.gethostname()), PORT)
+        host = socket.gethostbyname(socket.gethostname())
+        self.root_url = 'http://%s:%d' % (host, PORT)
 
     def __enter__(self):
         self.proc = Popen(

--- a/tests/test_spider.py
+++ b/tests/test_spider.py
@@ -1,4 +1,5 @@
-import os, tempfile
+import os, uuid, tempfile
+from urllib.parse import urlsplit
 
 from twisted.internet import defer
 from twisted.trial.unittest import TestCase
@@ -36,22 +37,21 @@ def html(content):
     return '<html><head></head><body>{}</body></html>'.format(content)
 
 
-def text_resource(content, name=None):
+def text_resource(content):
     class Page(Resource):
         isLeaf = True
         def render_GET(self, request):
             return content.encode()
-    if name:
-        Page.__name__ = name
     return Page
 
 
-SinglePage = text_resource(html('<b>hello</b>'), name='SinglePage')
+SinglePage = text_resource(html('<b>hello</b>'))
+SinglePage.__name__ = 'SinglePage'
 
 
 class Follow(Resource):
     def __init__(self):
-        Resource.__init__(self)
+        super().__init__()
         self.putChild(b'', text_resource(
             html('<a href="/one">one</a> | <a href="/two">two</a>'))())
         self.putChild(b'one', text_resource('one')())
@@ -97,7 +97,7 @@ class TestBasic(SpiderTestCase):
 
 class WithFile(Resource):
     def __init__(self):
-        Resource.__init__(self)
+        super().__init__()
         self.putChild(b'', text_resource(
             html('<a href="/file.pdf">file</a>'))())
         self.putChild(b'file.pdf', text_resource('pdf file content')())
@@ -127,7 +127,27 @@ class TestDocuments(SpiderTestCase):
             assert f.read() == 'pdf file content'
 
 
+def is_authenticated(request):
+    session_id = request.received_cookies.get(b'_uctest_auth')
+    is_auth = session_id == Login.session_id
+    if not is_auth and session_id:
+        print('erase header')
+        request.setHeader(b'set-cookie', b'_uctest_auth=')
+    return is_auth
+
+
+def authenticated_text(content):
+    class R(Resource):
+        def render_GET(self, request):
+            if not is_authenticated(request):
+                return Redirect(b'/login').render(request)
+            else:
+                return content.encode()
+    return R
+
+
 class Login(Resource):
+    session_id = None
 
     class Login(Resource):
         isLeaf = True
@@ -141,22 +161,48 @@ class Login(Resource):
         def render_POST(self, request):
             if request.args[b'login'][0] == b'admin' and \
                     request.args[b'password'][0] == b'secret':
-                request.setHeader(b'set-cookie', b'_uctest_auth=yes')
+                Login.session_id = bytes(uuid.uuid4().hex, 'ascii')
+                request.setHeader(
+                    b'set-cookie', b'_uctest_auth=' + Login.session_id)
             return Redirect(b'/').render(request)
 
     class Index(Resource):
         isLeaf = True
         def render_GET(self, request):
-            if request.received_cookies.get(b'_uctest_auth') == b'yes':
+            if is_authenticated(request):
                 return html('<a href="/hidden">Go get it</a>').encode()
             else:
                 return html('<a href="/login">Login</a>').encode()
 
     def __init__(self):
-        Resource.__init__(self)
-        self.putChild(b'', Login.Index())
-        self.putChild(b'login', Login.Login())
-        self.putChild(b'hidden', text_resource(html('hidden resource'))())
+        super().__init__()
+        self.putChild(b'', self.Index())
+        self.putChild(b'login', self.Login())
+        self.putChild(b'hidden', authenticated_text(html('hidden resource'))())
+
+
+class LoginWithLogout(Login):
+    class Logout(Resource):
+        isLeaf = True
+        def render_GET(self, request):
+            Login.session_id = None
+            request.setHeader(b'set-cookie', b'_uctest_auth=')
+            return html('you have been logged out').encode()
+
+    def __init__(self):
+        super().__init__()
+        self.putChild(b'hidden', authenticated_text(html(
+            '<a href="/one">one</a> | '
+            '<a href="/logout1">logout1</a> | '
+            '<a href="/two">two</a> | '
+           #'<a href="/logout2">logout2</a> | '
+            '<a href="/three">three</a>'
+            ))())
+        self.putChild(b'one', authenticated_text(html('1'))())
+        self.putChild(b'logout1', self.Logout())
+        self.putChild(b'two', authenticated_text(html('2'))())
+       #self.putChild(b'logout2', self.Logout())
+        self.putChild(b'three', authenticated_text(html('3'))())
 
 
 class TestAutologin(SpiderTestCase):
@@ -179,3 +225,15 @@ class TestAutologin(SpiderTestCase):
         assert hasattr(spider, 'collected_items')
         assert len(spider.collected_items) == 2
         assert spider.collected_items[1]['url'] == root_url + '/hidden'
+
+    @defer.inlineCallbacks
+    def test_login_with_logout(self):
+        ''' Login with logout.
+        '''
+        with MockServer(LoginWithLogout) as s:
+            root_url = s.root_url
+            yield self.crawler.crawl(url=root_url)
+        spider = self.crawler.spider
+        assert hasattr(spider, 'collected_items')
+        assert {urlsplit(item['url']).path for item in spider.collected_items}\
+            == {'/', '/hidden', '/one', '/two', '/three'}

--- a/tests/test_spider.py
+++ b/tests/test_spider.py
@@ -128,10 +128,9 @@ class TestDocuments(SpiderTestCase):
 
 
 def is_authenticated(request):
-    session_id = request.received_cookies.get(b'_uctest_auth')
-    is_auth = session_id == Login.session_id
-    if not is_auth and session_id:
-        print('erase header')
+    is_auth = request.received_cookies.get(b'_uctest_auth') == Login.session_id
+    # TODO - reset it only if it is present
+    if not is_auth and b'_uctest_auth' in request.received_cookies:
         request.setHeader(b'set-cookie', b'_uctest_auth=')
     return is_auth
 
@@ -152,6 +151,9 @@ class Login(Resource):
     class Login(Resource):
         isLeaf = True
         def render_GET(self, request):
+            # Erase cookie if it's wrong. Django does it, but I'm not sure
+            # all auth systems do it, so it'll be nice to work even without it.
+            is_authenticated(request)
             return html(
                 '<form action="/login" method="POSt">'
                 '<input type="text" name="login">'

--- a/tests/test_spider.py
+++ b/tests/test_spider.py
@@ -128,9 +128,9 @@ class TestDocuments(SpiderTestCase):
 
 
 def is_authenticated(request):
-    is_auth = request.received_cookies.get(b'_uctest_auth') == Login.session_id
-    # TODO - reset it only if it is present
-    if not is_auth and b'_uctest_auth' in request.received_cookies:
+    session_id = request.received_cookies.get(b'_uctest_auth')
+    is_auth = session_id == Login.session_id
+    if not is_auth and session_id:
         request.setHeader(b'set-cookie', b'_uctest_auth=')
     return is_auth
 
@@ -151,9 +151,6 @@ class Login(Resource):
     class Login(Resource):
         isLeaf = True
         def render_GET(self, request):
-            # Erase cookie if it's wrong. Django does it, but I'm not sure
-            # all auth systems do it, so it'll be nice to work even without it.
-            is_authenticated(request)
             return html(
                 '<form action="/login" method="POSt">'
                 '<input type="text" name="login">'
@@ -197,13 +194,13 @@ class LoginWithLogout(Login):
             '<a href="/one">one</a> | '
             '<a href="/logout1">logout1</a> | '
             '<a href="/two">two</a> | '
-           #'<a href="/logout2">logout2</a> | '
+            '<a href="/logout2">logout2</a> | '
             '<a href="/three">three</a>'
             ))())
         self.putChild(b'one', authenticated_text(html('1'))())
         self.putChild(b'logout1', self.Logout())
         self.putChild(b'two', authenticated_text(html('2'))())
-       #self.putChild(b'logout2', self.Logout())
+        self.putChild(b'logout2', self.Logout())
         self.putChild(b'three', authenticated_text(html('3'))())
 
 

--- a/undercrawler/directives/headless_horseman.lua
+++ b/undercrawler/directives/headless_horseman.lua
@@ -25,6 +25,7 @@ function main(splash)
   local method = get_arg(splash.args.http_method, "GET")
   local body = get_arg(splash.args.body, nil)
   local headers = get_arg(splash.args.headers, nil)
+  local cookies = get_arg(splash.args.cookies, nil)
   local visual = get_arg(splash.args.visual, false)
 
   -- 992px is Bootstrap's minimum "desktop" size. 744 gives the viewport
@@ -33,6 +34,9 @@ function main(splash)
   local viewport_width = splash.args.viewport_width or 992
   local viewport_height = splash.args.viewport_height or 744
 
+  if cookies then
+    splash:init_cookies(cookies)
+  end
   splash:autoload(splash.args.js_source)
 
   if debug then
@@ -91,6 +95,7 @@ function main(splash)
   render['url'] = splash:url()
   render['headers'] = last_response.headers
   render['http_status'] = last_response.status
+  render['cookies'] = splash:get_cookies()
 
   return render
 end

--- a/undercrawler/middleware/autologin.py
+++ b/undercrawler/middleware/autologin.py
@@ -149,14 +149,11 @@ class AutologinMiddleware:
         return bool(auth_cookies - response_cookies)
 
 
-
 def _cookies_to_har(cookies):
-    har_cookies = []
-    for c in cookies:
-        c = dict(c)
-        expires = c.get('expires')
-        if isinstance(expires, int):
-            tm = time.gmtime(expires)
-            c['expires'] = time.strftime("%Y-%m-%dT%H:%M:%SZ", tm)
-        har_cookies.append(c)
-    return har_cookies
+    # Leave only documented cookie attributes
+    return [{
+        'name': c['name'],
+        'value': c['value'],
+        'path': c.get('path', '/'),
+        'domain': c.get('domain', ''),
+        } for c in cookies]

--- a/undercrawler/middleware/autologin.py
+++ b/undercrawler/middleware/autologin.py
@@ -143,7 +143,6 @@ class AutologinMiddleware:
         return response
 
     def is_logout(self, response):
-        auth_cookies_names = {c['name'] for c in self.auth_cookies
-                              if c['value']}
-        return any(m.name in auth_cookies_names and m.value == ''
-                   for m in response.cookiejar)
+        auth_cookies = {c['name'] for c in self.auth_cookies if c['value']}
+        response_cookies = {m.name for m in response.cookiejar if m.value}
+        return bool(auth_cookies - response_cookies)

--- a/undercrawler/middleware/autologin.py
+++ b/undercrawler/middleware/autologin.py
@@ -113,6 +113,7 @@ class AutologinMiddleware:
             elif status == 'solved':
                 cookies = response.get('cookies')
                 if cookies:
+                    cookies = _cookies_to_har(cookies)
                     logger.debug('Got cookies after login %s', cookies)
                     return cookies
                 else:
@@ -146,3 +147,16 @@ class AutologinMiddleware:
         auth_cookies = {c['name'] for c in self.auth_cookies if c['value']}
         response_cookies = {m.name for m in response.cookiejar if m.value}
         return bool(auth_cookies - response_cookies)
+
+
+
+def _cookies_to_har(cookies):
+    har_cookies = []
+    for c in cookies:
+        c = dict(c)
+        expires = c.get('expires')
+        if isinstance(expires, int):
+            tm = time.gmtime(expires)
+            c['expires'] = time.strftime("%Y-%m-%dT%H:%M:%SZ", tm)
+        har_cookies.append(c)
+    return har_cookies

--- a/undercrawler/settings.py
+++ b/undercrawler/settings.py
@@ -32,6 +32,7 @@ DOWNLOADER_MIDDLEWARES = {
 }
 if USE_SPLASH:
     DOWNLOADER_MIDDLEWARES.update({
+        'scrapyjs.SplashCookiesMiddleware': 723,
         'scrapyjs.SplashMiddleware': 725,
         'scrapy.downloadermiddlewares.httpcompression'
             '.HttpCompressionMiddleware': 810,


### PR DESCRIPTION
Using cookie middleware from scrapy-splash: this fixes some bugs with logout detection. Also, autologin middleware tests added in test_spider.

But first I'll need to debug the travis build.