### PR TITLE
Adjust crawling speed with AutoThrottle middleware

### DIFF
--- a/undercrawler/middleware/__init__.py
+++ b/undercrawler/middleware/__init__.py
@@ -1,2 +1,3 @@
 from .avoid_dup_content import *
 from .autologin import *
+from .throttle import *

--- a/undercrawler/middleware/throttle.py
+++ b/undercrawler/middleware/throttle.py
@@ -1,0 +1,31 @@
+from scrapy.extensions.throttle import AutoThrottle
+from scrapy.exceptions import NotConfigured
+from scrapyjs.response import SplashJsonResponse
+
+
+class SplashAwareAutoThrottle(AutoThrottle):
+    def __init__(self, crawler):
+        self.crawler = crawler
+        self.target_concurrency = \
+            crawler.settings.getfloat('AUTOTHROTTLE_TARGET_CONCURRENCY')
+        self.debug = crawler.settings.getbool('AUTOTHROTTLE_DEBUG')
+
+    @classmethod
+    def from_crawler(cls, crawler):
+        if not crawler.settings.getbool('SPLASH_AUTOTHROTTLE_ENABLED'):
+            raise NotConfigured
+        return cls(crawler)
+
+    def process_request(self, request, spider):
+        if not hasattr(spider, 'download_delay'):
+            self._spider_opened(spider)
+
+    def process_response(self, request, response, spider):
+        if isinstance(response, SplashJsonResponse) and 'har' in response.data:
+            pages = response.data['har']['log'].get('pages')
+            if pages:
+                t_ms = pages[-1].get('pageTimings', {}).get('onContentLoad')
+                if t_ms is not None:
+                    request.meta['download_latency'] = t_ms / 1000
+        self._response_downloaded(response, request, spider)
+        return response

--- a/undercrawler/settings.py
+++ b/undercrawler/settings.py
@@ -45,12 +45,12 @@ COOKIES_ENABLED = False
 # Run full headless-horseman scripts
 RUN_HH = True
 
-DOWNLOAD_DELAY = 0.2
+DOWNLOAD_DELAY = 0.2  # Adjusted by autothrottle
 SPLASH_AUTOTHROTTLE_ENABLED = True
 
+# HH scripts in Splash take a while to execute, so use higher values here
 CONCURRENT_REQUESTS = 32
-# Using smaller value here to retry less requests due to logouts
-CONCURRENT_REQUESTS_PER_DOMAIN = 8
+CONCURRENT_REQUESTS_PER_DOMAIN = 32
 
 DEPTH_PRIORITY = 1
 SCHEDULER_DISK_QUEUE = 'scrapy.squeues.PickleFifoDiskQueue'

--- a/undercrawler/settings.py
+++ b/undercrawler/settings.py
@@ -29,6 +29,7 @@ ITEM_PIPELINES = {'undercrawler.documents_pipeline.CDRDocumentsPipeline': 1}
 DOWNLOADER_MIDDLEWARES = {
     'undercrawler.middleware.AvoidDupContentMiddleware': 200,
     'undercrawler.middleware.AutologinMiddleware': 584,
+    'undercrawler.middleware.SplashAwareAutoThrottle': 722,
 }
 if USE_SPLASH:
     DOWNLOADER_MIDDLEWARES.update({
@@ -44,11 +45,12 @@ COOKIES_ENABLED = False
 # Run full headless-horseman scripts
 RUN_HH = True
 
-DOWNLOAD_DELAY = 3
+DOWNLOAD_DELAY = 0.2
+SPLASH_AUTOTHROTTLE_ENABLED = True
 
 CONCURRENT_REQUESTS = 32
-# Using small value here to retry less requests due to logouts
-CONCURRENT_REQUESTS_PER_DOMAIN = 4
+# Using smaller value here to retry less requests due to logouts
+CONCURRENT_REQUESTS_PER_DOMAIN = 8
 
 DEPTH_PRIORITY = 1
 SCHEDULER_DISK_QUEUE = 'scrapy.squeues.PickleFifoDiskQueue'


### PR DESCRIPTION
It uses AutoThrottle extension, but calls it after the splash middleware, so we can access the timings of the response processed by splash middleware.

I am not sure I've chosen the best way to get timings from splash.