### PR TITLE
Fix domain regexp

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 git+https://github.com/scrapy/scrapy.git@288f8c09f8bac4c92f49332c8a5f5a21a182cc15
 botocore
-git+https://github.com/scrapy-plugins/scrapy-splash.git@bc8ddfd6732b5db40742dfe9bc251e4555ecd2ca
+scrapy-splash==0.6
 Formasaurus[with_deps]==0.7.2
 autopager==0.1
 datasketch==0.1.35

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 git+https://github.com/scrapy/scrapy.git@288f8c09f8bac4c92f49332c8a5f5a21a182cc15
 botocore
-scrapy-splash==0.5
+git+https://github.com/scrapy-plugins/scrapy-splash.git@bc8ddfd6732b5db40742dfe9bc251e4555ecd2ca
 Formasaurus[with_deps]==0.7.2
 autopager==0.1
 datasketch==0.1.35

--- a/tests/test_dupe_filter.py
+++ b/tests/test_dupe_filter.py
@@ -1,0 +1,17 @@
+from undercrawler.dupe_filter import DupeFilter
+from scrapy_splash import SplashRequest
+
+
+def test_dupe_filter():
+    dupe_filter = DupeFilter()
+    url_fp = lambda url: dupe_filter.request_fingerprint(SplashRequest(url))
+    assert url_fp('http://example.com') == \
+           url_fp('https://example.com')
+    assert url_fp('http://www.example.com/foo?a=1&b=1') == \
+           url_fp('http://example.com/foo?b=1&a=1')
+    assert url_fp('http://example.com/foo') != \
+           url_fp('http://example.com/bar')
+    assert url_fp('http://www.example.com/foo?a=1&b=1') == \
+           url_fp('http://example.com/foo?b=1&a=1')
+    assert url_fp('http://www.example.com/foo#a') != \
+           url_fp('http://example.com/foo#b')

--- a/undercrawler/dupe_filter.py
+++ b/undercrawler/dupe_filter.py
@@ -1,7 +1,6 @@
 import re
 from copy import deepcopy
 
-from scrapy.utils.url import canonicalize_url
 from scrapy_splash import SplashAwareDupeFilter
 
 
@@ -11,10 +10,7 @@ class DupeFilter(SplashAwareDupeFilter):
     """
     def request_fingerprint(self, request):
         if not request.meta.get('_splash_processed'):
-            # canonicalize_url required only due to a bug (?) in scrapy_splash
-            url = canonicalize_url(
-                re.sub(r'^https?://(www\.)?', 'http://', request.url),
-                keep_fragments=True)
+            url = re.sub(r'^https?://(www\.)?', 'http://', request.url)
             kwargs = {'url': url}
             if 'splash' in request.meta:
                 kwargs['meta'] = deepcopy(request.meta)

--- a/undercrawler/dupe_filter.py
+++ b/undercrawler/dupe_filter.py
@@ -1,0 +1,23 @@
+import re
+from copy import deepcopy
+
+from scrapy.utils.url import canonicalize_url
+from scrapy_splash import SplashAwareDupeFilter
+
+
+class DupeFilter(SplashAwareDupeFilter):
+    """
+    Consider same urls with and without www as duplicates.
+    """
+    def request_fingerprint(self, request):
+        if not request.meta.get('_splash_processed'):
+            # canonicalize_url required only due to a bug (?) in scrapy_splash
+            url = canonicalize_url(
+                re.sub(r'^https?://(www\.)?', 'http://', request.url),
+                keep_fragments=True)
+            kwargs = {'url': url}
+            if 'splash' in request.meta:
+                kwargs['meta'] = deepcopy(request.meta)
+                kwargs['meta']['splash'].setdefault('args', {})['url'] = url
+            request = request.replace(**kwargs)
+        return super().request_fingerprint(request)

--- a/undercrawler/settings.py
+++ b/undercrawler/settings.py
@@ -6,7 +6,6 @@ NEWSPIDER_MODULE = 'undercrawler.spiders'
 ROBOTSTXT_OBEY = False
 DEPTH_LIMIT = 20
 
-USE_SPLASH = True
 SPLASH_URL = 'http://127.0.0.1:8050'
 
 AUTOLOGIN_URL = 'http://127.0.0.1:8089'
@@ -30,15 +29,12 @@ DOWNLOADER_MIDDLEWARES = {
     'undercrawler.middleware.AvoidDupContentMiddleware': 200,
     'undercrawler.middleware.AutologinMiddleware': 584,
     'undercrawler.middleware.SplashAwareAutoThrottle': 722,
+    'scrapy_splash.SplashCookiesMiddleware': 723,
+    'scrapy_splash.SplashMiddleware': 725,
+    'scrapy.downloadermiddlewares.httpcompression'
+        '.HttpCompressionMiddleware': 810,
 }
-if USE_SPLASH:
-    DOWNLOADER_MIDDLEWARES.update({
-        'scrapy_splash.SplashCookiesMiddleware': 723,
-        'scrapy_splash.SplashMiddleware': 725,
-        'scrapy.downloadermiddlewares.httpcompression'
-            '.HttpCompressionMiddleware': 810,
-    })
-    DUPEFILTER_CLASS = 'scrapy_splash.SplashAwareDupeFilter'
+DUPEFILTER_CLASS = 'undercrawler.dupe_filter.DupeFilter'
 
 SPIDER_MIDDLEWARES = {
     'scrapy_splash.SplashDeduplicateArgsMiddleware': 100,

--- a/undercrawler/spiders/base_spider.py
+++ b/undercrawler/spiders/base_spider.py
@@ -372,7 +372,7 @@ def allowed_re(url, hard_url_constraint):
     r"""
     Construct a regexp to check for allowed urls.
     >>> allowed_re('http://www.example.com/foo', True)
-    re.compile('^https?://(www\\.)?example\\.com/foo', re.IGNORECASE)
+    re.compile('^https?://(www\\.)?example\\.com\\/foo', re.IGNORECASE)
     >>> allowed_re('http://www.example.com/foo', False)
     re.compile('^https?://(www\\.)?example\\.com', re.IGNORECASE)
     >>> allowed_re('https://example.com/foo', False)
@@ -387,5 +387,4 @@ def allowed_re(url, hard_url_constraint):
         p = urlsplit(url)
         url = '{}://{}'.format(p.scheme, p.netloc)
     url = re.sub(http_www, '', url)
-    url = re.sub(r'\.', r'\\.', url)
-    return re.compile(http_www + url, re.I)
+    return re.compile(http_www + re.escape(url), re.I)

--- a/undercrawler/spiders/base_spider.py
+++ b/undercrawler/spiders/base_spider.py
@@ -64,7 +64,8 @@ class BaseSpider(scrapy.Spider):
             **kwargs)
 
     def parse_first(self, response):
-        self.allowed += (self._allowed_re(response.url),)
+        self.allowed += (allowed_re(
+            response.url, self.settings.getbool('HARD_URL_CONSTRAINT')),)
         self.logger.info('Updated allowed regexps: %s', self.allowed)
         yield from self.parse(response)
 
@@ -197,12 +198,6 @@ class BaseSpider(scrapy.Spider):
             url=url,
             version=2.0,
             **extra)
-
-    def _allowed_re(self, url):
-        http_www = r'^https?://(www\.)?'
-        if not self.settings.getbool('HARD_URL_CONSTRAINT'):
-            url = urlsplit(url).netloc
-        return re.compile(http_www + re.sub(http_www, '', url), re.I)
 
     def _pagination_urls(self, response):
         return [
@@ -371,3 +366,26 @@ def link_to_url(link):
 def url_fingerprint(url):
     url = canonicalize_url(url, keep_fragments=True)
     return hashlib.sha1(url.encode()).hexdigest()
+
+
+def allowed_re(url, hard_url_constraint):
+    r"""
+    Construct a regexp to check for allowed urls.
+    >>> allowed_re('http://www.example.com/foo', True)
+    re.compile('^https?://(www\\.)?example\\.com/foo', re.IGNORECASE)
+    >>> allowed_re('http://www.example.com/foo', False)
+    re.compile('^https?://(www\\.)?example\\.com', re.IGNORECASE)
+    >>> allowed_re('https://example.com/foo', False)
+    re.compile('^https?://(www\\.)?example\\.com', re.IGNORECASE)
+    >>> bool(allowed_re('https://example.com/foo', False).match('http://www.example.com/bar'))
+    True
+    >>> bool(allowed_re('https://example.com/foo', True).match('http://www.example.com/bar'))
+    False
+    """
+    http_www = r'^https?://(www\.)?'
+    if not hard_url_constraint:
+        p = urlsplit(url)
+        url = '{}://{}'.format(p.scheme, p.netloc)
+    url = re.sub(http_www, '', url)
+    url = re.sub(r'\.', r'\\.', url)
+    return re.compile(http_www + url, re.I)

--- a/undercrawler/spiders/base_spider.py
+++ b/undercrawler/spiders/base_spider.py
@@ -370,21 +370,43 @@ def url_fingerprint(url):
 
 def allowed_re(url, hard_url_constraint):
     r"""
-    Construct a regexp to check for allowed urls.
+    Construct a regexp to check for allowed urls. The url must be within
+    the start domain or lower (unless hard_url_constraint is True), but can
+    have or not have "www" subdomain and any of http/https protocols.
+
     >>> allowed_re('http://www.example.com/foo', True)
     re.compile('^https?://(www\\.)?example\\.com\\/foo', re.IGNORECASE)
     >>> allowed_re('http://www.example.com/foo', False)
-    re.compile('^https?://(www\\.)?example\\.com', re.IGNORECASE)
+    re.compile('^https?://([a-z0-9-.]+\\.)?example\\.com', re.IGNORECASE)
     >>> allowed_re('https://example.com/foo', False)
-    re.compile('^https?://(www\\.)?example\\.com', re.IGNORECASE)
+    re.compile('^https?://([a-z0-9-.]+\\.)?example\\.com', re.IGNORECASE)
+    >>> allowed_re('https://blog.example.com/foo', True)
+    re.compile('^https?://blog\\.example\\.com\\/foo', re.IGNORECASE)
+    >>> allowed_re('https://blog.example.com/foo', False)
+    re.compile('^https?://([a-z0-9-.]+\\.)?blog\\.example\\.com', re.IGNORECASE)
     >>> bool(allowed_re('https://example.com/foo', False).match('http://www.example.com/bar'))
     True
     >>> bool(allowed_re('https://example.com/foo', True).match('http://www.example.com/bar'))
     False
+    >>> bool(allowed_re('https://example.com/foo', False).match('http://blog.example.com/bar'))
+    True
+    >>> bool(allowed_re('http://example.com/foo', False).match('http://blog.example.com/foo'))
+    True
+    >>> bool(allowed_re('http://blog.example.com', False).match('http://news.example.com'))
+    False
     """
-    http_www = r'^https?://(www\.)?'
     if not hard_url_constraint:
         p = urlsplit(url)
         url = '{}://{}'.format(p.scheme, p.netloc)
+    http = r'^https?://'
+    http_www = http + r'(www\.)?'
     url = re.sub(http_www, '', url)
-    return re.compile(http_www + re.escape(url), re.I)
+    if hard_url_constraint:
+        p = urlsplit('http://' + url)
+        if len(p.netloc.split('.')) > 2:
+            regexp_prefix = http
+        else:
+            regexp_prefix = http_www
+    else:
+        regexp_prefix = http + r'([a-z0-9-.]+\.)?'
+    return re.compile(regexp_prefix + re.escape(url), re.I)


### PR DESCRIPTION
This should fix #37 - it correctly normalizes and escapes initial allowed regexp, and adds a duplicate filter that does not take www and http/https into account.
Also, I'm not super sure here, but I maybe the duplicate filter from scrapy-splash should apply canonicalize_url without removing fragments to ``request.meta['splash']['args']['url']`` when calculating request fingerprint.