### PR TITLE
Non-blocking autologin

### DIFF
--- a/tests/test_autologin.py
+++ b/tests/test_autologin.py
@@ -10,7 +10,7 @@ from twisted.web.util import Redirect
 from twisted.web.server import NOT_DONE_YET
 
 from .mockserver import MockServer
-from .test_spider import html, SpiderTestCase, find_item, paths_set
+from .test_spider import html, SpiderTestCase, TestBasic, find_item, paths_set
 
 
 def get_session_id(request):
@@ -127,6 +127,10 @@ class LoginWithLogout(Login):
         self.putChild(b'l0gout2', self._Logout())
         self.putChild(b'three', authenticated_text(html('3'))())
         self.putChild(b'slow', authenticated_text(html('slow'), delay=1.0)())
+
+
+class TestSkip(TestBasic):
+    settings = {'_AUTOLOGIN_FORCE_SKIP': True}
 
 
 class TestAutologin(SpiderTestCase):

--- a/tests/test_autologin.py
+++ b/tests/test_autologin.py
@@ -4,9 +4,10 @@ from __future__ import absolute_import
 import tempfile
 import uuid
 
-from twisted.internet import defer
+from twisted.internet import defer, reactor
 from twisted.web.resource import Resource
 from twisted.web.util import Redirect
+from twisted.web.server import NOT_DONE_YET
 
 from .mockserver import MockServer
 from .test_spider import html, SpiderTestCase, find_item, paths_set
@@ -28,13 +29,19 @@ def is_authenticated(request):
         return False
 
 
-def authenticated_text(content):
+def authenticated_text(content, delay=0):
     class R(Resource):
         def render_GET(self, request):
+            reactor.callLater(delay, self._delayedRender, request)
+            return NOT_DONE_YET
+
+        def _delayedRender(self, request):
             if not is_authenticated(request):
-                return Redirect(b'/login').render(request)
+                result = Redirect(b'/login').render(request)
             else:
-                return content.encode()
+                result = content.encode()
+            request.write(result)
+            request.finish()
     return R
 
 
@@ -111,13 +118,15 @@ class LoginWithLogout(Login):
             '<a href="/l0gout1">l0gout1</a> | '
             '<a href="/two">two</a> | '
             '<a href="/l0gout2">l0gout2</a> | '
-            '<a href="/three">three</a>'
+            '<a href="/three">three</a> | '
+            '<a href="/slow">slow</a>'
             ))())
         self.putChild(b'one', authenticated_text(html('1'))())
         self.putChild(b'l0gout1', self._Logout())
         self.putChild(b'two', authenticated_text(html('2'))())
         self.putChild(b'l0gout2', self._Logout())
         self.putChild(b'three', authenticated_text(html('3'))())
+        self.putChild(b'slow', authenticated_text(html('slow'), delay=1.0)())
 
 
 class TestAutologin(SpiderTestCase):
@@ -159,7 +168,7 @@ class TestAutologin(SpiderTestCase):
         spider = self.crawler.spider
         assert hasattr(spider, 'collected_items')
         assert paths_set(spider.collected_items) == \
-               {'/', '/hidden', '/one', '/two', '/three', '/file.pdf'}
+               {'/', '/hidden', '/one', '/two', '/three', '/file.pdf', '/slow'}
 
 
 class TestAutoLoginCustomHeaders(SpiderTestCase):

--- a/tests/test_autologin.py
+++ b/tests/test_autologin.py
@@ -175,16 +175,35 @@ class TestAutologin(SpiderTestCase):
                {'/', '/hidden', '/one', '/two', '/three', '/file.pdf', '/slow'}
 
 
+class TestPending(SpiderTestCase):
+    settings = {
+        'USERNAME': 'admin',
+        'PASSWORD': 'secret',
+        'LOGIN_URL': '/login',
+        'LOGOUT_URL': 'action=l0gout',
+        'AUTOLOGIN_DOWNLOAD_DELAY': 0.01,
+        '_AUTOLOGIN_N_PEND': 3,
+    }
+
+    @defer.inlineCallbacks
+    def test_login(self):
+        with MockServer(Login) as s:
+            root_url = s.root_url
+            yield self.crawler.crawl(url=root_url)
+        spider = self.crawler.spider
+        assert hasattr(spider, 'collected_items')
+        assert len(spider.collected_items) == 2
+        assert paths_set(spider.collected_items) == {'/', '/hidden'}
+
+
 class TestAutoLoginCustomHeaders(SpiderTestCase):
-    @property
-    def settings(self):
-        return {
-            'USERNAME': 'admin',
-            'PASSWORD': 'secret',
-            'LOGIN_URL': '/login',
-            'USER_AGENT': 'MyCustomAgent',
-            'AUTOLOGIN_DOWNLOAD_DELAY': 0.01,
-        }
+    settings = {
+        'USERNAME': 'admin',
+        'PASSWORD': 'secret',
+        'LOGIN_URL': '/login',
+        'USER_AGENT': 'MyCustomAgent',
+        'AUTOLOGIN_DOWNLOAD_DELAY': 0.01,
+    }
 
     @defer.inlineCallbacks
     def test_login(self):

--- a/undercrawler/middleware/autologin.py
+++ b/undercrawler/middleware/autologin.py
@@ -45,7 +45,9 @@ class AutologinMiddleware:
         self.user_agent = s.get('USER_AGENT')
         self.autologin_download_delay = s.get('AUTOLOGIN_DOWNLOAD_DELAY')
         self.logout_url = s.get('LOGOUT_URL')
+        # _force_skip and _n_pend and for testing only
         self._force_skip = s.get('_AUTOLOGIN_FORCE_SKIP')
+        self._n_pend = s.get('_AUTOLOGIN_N_PEND')
         self._login_df = None
         auth_cookies = s.get('AUTH_COOKIES')
         self.skipped = False
@@ -107,6 +109,9 @@ class AutologinMiddleware:
             status = response_data['status']
             if self._force_skip:
                 status = 'skipped'
+            elif self._n_pend:
+                self._n_pend -= 1
+                status = 'pending'
             logger.debug('Got login response with status "%s"', status)
             if status == 'pending':
                 continue

--- a/undercrawler/middleware/autologin.py
+++ b/undercrawler/middleware/autologin.py
@@ -150,7 +150,8 @@ class AutologinMiddleware:
             headers={'content-type': 'application/json'},
             callback=partial(self._on_login_response, url, spider=spider),
             dont_filter=True,
-            meta={'skip_autologin': True})
+            meta={'skip_autologin': True},
+            priority=1000)
 
     def process_response(self, request, response, spider):
         ''' If we were logged out, login again and retry request.

--- a/undercrawler/spiders/base_spider.py
+++ b/undercrawler/spiders/base_spider.py
@@ -112,7 +112,7 @@ class BaseSpider(scrapy.Spider):
         # they're be filtered out by a dupefilter.
         normal_urls = {link_to_url(link) for link in
                        self.link_extractor.extract_links(response)
-                       if not self._looks_like_logout(link)}
+                       if not self._looks_like_logout(link, response)}
         for url in normal_urls:
             yield request(url)
 
@@ -160,7 +160,7 @@ class BaseSpider(scrapy.Spider):
                 self.images_link_extractor, self.files_link_extractor]:
             urls.update(
                 link_to_url(link) for link in extractor.extract_links(response)
-                if not self._looks_like_logout(link))
+                if not self._looks_like_logout(link, response))
         urls.difference_update(map(canonicalize_url, normal_urls))
         for url in urls:
             fp = url_fingerprint(url)
@@ -261,8 +261,9 @@ class BaseSpider(scrapy.Spider):
     def handled_search_forms(self):
         return self.state.setdefault('handled_search_forms', set())
 
-    def _looks_like_logout(self, link):
-        if not self.settings.getbool('AUTOLOGIN_ENABLED'):
+    def _looks_like_logout(self, link, response):
+        if not self.settings.getbool('AUTOLOGIN_ENABLED') or not \
+                response.meta.get('autologin_active'):
             return False
         return _looks_like_logout(link)
 


### PR DESCRIPTION
I make requests to autologin via normal scrapy requests and process responses in callbacks. Requests before login and during logout are queued and scheduled after login.