### PR TITLE
Optional splash support

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ Useful options to tweak (add to the above command via ``-s NAME=value``):
 - ``RUN_HH`` - set to 0 to skip running full headless-horesman scripts
 - ``SEARCH_TERMS_FILE`` - file with extra search terms to use (one per line)
 - ``SPLASH_URL`` - url of the splash instance
+- ``USE_SPLASH`` - set to 0 to crawl without using splash
 - ``USERNAME``, ``PASSWORD``, ``LOGIN_URL`` - specify values to pass to
   autologin - use them if you do not want to use autologin keychain UI.
   ``LOGIN_URL`` is a relative url.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,34 @@
+import os
+
+import pytest
+from scrapy.settings import Settings
+from scrapy.crawler import CrawlerRunner
+
+import undercrawler.settings
+from undercrawler.spiders import BaseSpider
+
+
+pytest_plugins = 'pytest_twisted'
+
+
+@pytest.fixture(params=[False, True])
+def settings(request):
+    s = Settings()
+    s.setmodule(undercrawler.settings)
+    s.update({
+        'DOWNLOAD_DELAY': 0.01,
+        'AUTOTHROTTLE_START_DELAY': 0.01,
+        'RUN_HH': False,
+        'USE_SPLASH': request.param,
+        })
+    s['ITEM_PIPELINES']['tests.utils.CollectorPipeline'] = 100
+    splash_url = os.environ.get('SPLASH_URL')
+    if splash_url:
+        s['SPLASH_URL'] = splash_url
+    return s
+
+
+def make_crawler(settings, **extra_settings):
+    settings.update(extra_settings)
+    runner = CrawlerRunner(settings)
+    return runner.create_crawler(BaseSpider)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,6 +1,59 @@
+from urllib.parse import urlsplit, urlunsplit
+
+import pytest
+from scrapy.utils.log import configure_logging
+from scrapy.utils.python import to_bytes
+from twisted.internet import defer
+from twisted.web.resource import Resource
+
+
 class CollectorPipeline:
     def process_item(self, item, spider):
         if not hasattr(spider, 'collected_items'):
             spider.collected_items = []
         spider.collected_items.append(item)
         return item
+
+
+# make the module importable without running py.test
+try:
+    inlineCallbacks = pytest.inlineCallbacks
+except AttributeError:
+    inlineCallbacks = defer.inlineCallbacks
+
+
+configure_logging()
+
+
+def html(content):
+    return '<html><head></head><body>{}</body></html>'.format(content)
+
+
+def text_resource(content):
+    class Page(Resource):
+        isLeaf = True
+        def render_GET(self, request):
+            request.setHeader(b'content-type', b'text/html')
+            return to_bytes(content)
+    return Page
+
+
+def find_item(substring, items):
+    [item] = [item for item in items if substring in item['url']]
+    return item
+
+
+def paths_set(items):
+    _paths_set = set()
+    for item in items:
+        p = urlsplit(item['url'])
+        _paths_set.add(
+            urlunsplit(['', '', p.path or '/', p.query, p.fragment]))
+    return _paths_set
+
+
+def test_paths_set():
+    assert paths_set([
+        {'url': 'https://google.com/foo?query=bar'},
+        {'url': 'http://google.com/'},
+        ]) == {'/foo?query=bar', '/'}

--- a/undercrawler/crazy_form_submitter.py
+++ b/undercrawler/crazy_form_submitter.py
@@ -3,7 +3,6 @@ import random
 import string
 
 from scrapy.http.request.form import _get_inputs as get_form_data
-from scrapy_splash import SplashRequest, SplashFormRequest
 
 
 logger = logging.getLogger(__name__)
@@ -47,7 +46,6 @@ def search_form_requests(url, form, meta,
                     search_term, url, priority,
                     ' with random refinement' if do_random_refinement else '')
                 yield dict(
-                    cls=SplashFormRequest,
                     url=url,
                     formdata=formdata,
                     method=form.method,

--- a/undercrawler/middleware/__init__.py
+++ b/undercrawler/middleware/__init__.py
@@ -1,1 +1,2 @@
 from .throttle import *
+from .cookies import *

--- a/undercrawler/middleware/cookies.py
+++ b/undercrawler/middleware/cookies.py
@@ -1,0 +1,10 @@
+from autologin_middleware import ExposeCookiesMiddleware
+from scrapy.exceptions import NotConfigured
+
+
+class CookiesMiddlewareIfNoSplash(ExposeCookiesMiddleware):
+    @classmethod
+    def from_crawler(cls, crawler):
+        if crawler.settings.getbool('USE_SPLASH'):
+            raise NotConfigured
+        return super().from_crawler(crawler)

--- a/undercrawler/settings.py
+++ b/undercrawler/settings.py
@@ -15,6 +15,8 @@ CRAZY_SEARCH_ENABLED = True
 CDR_CRAWLER = 'scrapy undercrawler'
 CDR_TEAM = 'HG'
 
+USE_SPLASH = True
+
 PREFER_PAGINATION = True
 ADBLOCK = False
 MAX_DOMAIN_SEARCH_FORMS = 10
@@ -28,6 +30,8 @@ ITEM_PIPELINES = {'undercrawler.documents_pipeline.CDRDocumentsPipeline': 1}
 DOWNLOADER_MIDDLEWARES = {
     'maybedont.scrapy_middleware.AvoidDupContentMiddleware': 200,
     'autologin_middleware.AutologinMiddleware': 605,
+    'scrapy.downloadermiddlewares.cookies.CookiesMiddleware': None,
+    'undercrawler.middleware.CookiesMiddlewareIfNoSplash': 700,
     'undercrawler.middleware.SplashAwareAutoThrottle': 722,
     'scrapy_splash.SplashCookiesMiddleware': 723,
     'scrapy_splash.SplashMiddleware': 725,
@@ -45,7 +49,8 @@ USER_AGENT = ('Mozilla/5.0 (X11; Linux i686) AppleWebKit/537.36 '
               '(KHTML, like Gecko) Ubuntu Chromium/43.0.2357.130 '
               'Chrome/43.0.2357.130 Safari/537.36')
 
-COOKIES_ENABLED = False
+# enabled in CookiesMiddlewareIfNoSplash only when USE_SPLASH is False
+COOKIES_ENABLED = True
 
 # Run full headless-horseman scripts
 RUN_HH = True


### PR DESCRIPTION
Makes splash optional.
In order to run all crawling tests with and without splash, parametrized fixtures from pytest are used, so I had to port them away from unittest-style tests to function-style tests, using pytest-twisted. Maybe there is some easier way to achieve the same?