### PR TITLE
Do not fail too early - return error pages as well

### DIFF
--- a/undercrawler/directives/headless_horseman.lua
+++ b/undercrawler/directives/headless_horseman.lua
@@ -58,9 +58,9 @@ function main(splash)
   splash:autoload("__headless_horseman__.patchAll();")
   splash:set_viewport_size(viewport_width, viewport_height)
   local ok, reason = splash:go{
-    url, http_method=http_method, headers=headers, body=body }
+    url, http_method=http_method, headers=headers, body=body}
   if #(splash:history()) == 0 then
-    assert(false, reason)
+    error(reason)
   end
   splash:lock_navigation()
 

--- a/undercrawler/directives/headless_horseman.lua
+++ b/undercrawler/directives/headless_horseman.lua
@@ -57,7 +57,11 @@ function main(splash)
 
   splash:autoload("__headless_horseman__.patchAll();")
   splash:set_viewport_size(viewport_width, viewport_height)
-  assert(splash:go{url, http_method=http_method, headers=headers, body=body})
+  local ok, reason = splash:go{
+    url, http_method=http_method, headers=headers, body=body }
+  if #(splash:history()) == 0 then
+    assert(false, reason)
+  end
   splash:lock_navigation()
 
   -- Run a battery of Headless Horseman tests.


### PR DESCRIPTION
If we render a page with 500 status code, we should decide what to do on the scrapy side, and must return everything we can from the splash side. In practice it is useful for sites that set 500 status on all pages to confuse bots.
