### PR TITLE
Dockerfile for running undercrawler with arachnado

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,12 @@
+venv
+.tox
+tests
+*.json
+*.jl
+.git
+*.txt
+!requirements.txt
+**/__pycache__
+**/*.pyc
+*.egg-info
+_sup

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ services:
     - docker
 
 before_install:
-    - docker run -d -p 8050:8050 scrapinghub/splash:master
+    - docker run -d -p 8050:8050 --network host scrapinghub/splash
     # Autologin
     - pip install -U pip wheel
     - pip install git+https://github.com/TeamHG-Memex/autologin.git

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM arachnado
+
+WORKDIR /undercrawler
+
+COPY requirements.txt .
+RUN pip install -r requirements.txt && \
+    formasaurus init
+COPY . .
+RUN pip install -e .

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ Useful options to tweak (add to the above command via ``-s NAME=value``):
 - ``SCREENSHOTS`` - set to 1 to save screenshots while crawling (make sure
   you do not change the logging level from default ``DEBUG``).
 - ``SPLASH_URL`` - url of the splash instance
-- ``USE_SPLASH`` - set to 0 to crawl without using splash
+  (if empty, crawl without using splash)
 
 Pages are stored in CDRv2 format, with the following custom fields inside
 ``extracted_metadata``:

--- a/README.md
+++ b/README.md
@@ -62,6 +62,10 @@ Requires Python 3.4:
 You also will need Splash (but you can just use docker, see below),
 and install [Autologin](https://github.com/TeamHG-Memex/autologin).
 
+There is also an option to run undercrawler with arachnado in a docker container:
+see the [undercrawler-arachnado](./undercrawler-arachnado/README.md)
+folder.
+
 
 Run crawler
 -----------
@@ -74,9 +78,9 @@ Start [Autologin](https://github.com/TeamHG-Memex/autologin) HTTP API
 with the ``autologin-http-api`` command,
 and the UI server with ``autologin-server``.
 
-Specify url to crawl via the ``url`` param, and run the ``base`` spider:
+Specify url to crawl via the ``url`` param, and run the ``undercrawler`` spider:
 
-    scrapy crawl base -a url=http://127.0.0.1:8001
+    scrapy crawl undercrawler -a url=http://127.0.0.1:8001
 
 You can also specify a file to read urls from, with ``-a url=./urls.txt``,
 but in this case you must disable autologin with ``-s AUTOLOGIN_ENABLED=0``,

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
 scrapy==1.1.0
 botocore
 scrapy-splash==0.6
-git+https://github.com/TeamHG-Memex/autologin-middleware.git
-git+https://github.com/TeamHG-Memex/MaybeDont.git
+autologin-middleware
+MaybeDont
 Formasaurus[with_deps]>=0.8
 autopager==0.2
 datasketch==0.2.3

--- a/scripts/gen_supervisor_configs.py
+++ b/scripts/gen_supervisor_configs.py
@@ -10,7 +10,7 @@ directory = {root}
 stopsignal = INT
 stopwaitsecs = 360
 autostart = false
-command = {scrapy} crawl base -a url={url} -s LOG_FILE={log} -o {out} -s JOBDIR={job} {extra}
+command = {scrapy} crawl undercrawler -a url={url} -s LOG_FILE={log} -o {out} -s JOBDIR={job} {extra}
 log_stderr = true
 '''
 

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,16 @@
 from setuptools import setup
-# Just to enable testing via tox, not meant to be published
-setup(name='undercrawler', packages=['undercrawler'])
+
+
+setup(
+    name='undercrawler',
+    packages=['undercrawler'],
+    install_requires=[
+        'scrapy>=1.1.0',
+        'botocore',
+        'scrapy-splash>=0.6',
+        'autologin-middleware',
+        'MaybeDont',
+        'Formasaurus[with_deps]>=0.8',
+        'autopager>=0.2',
+    ],
+)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -20,12 +20,14 @@ def settings(request):
         'DOWNLOAD_DELAY': 0.01,
         'AUTOTHROTTLE_START_DELAY': 0.01,
         'RUN_HH': False,
-        'USE_SPLASH': use_splash,
         })
     s['ITEM_PIPELINES']['tests.utils.CollectorPipeline'] = 100
-    splash_url = os.environ.get('SPLASH_URL')
-    if splash_url:
-        s['SPLASH_URL'] = splash_url
+    if use_splash:
+        splash_url = os.environ.get('SPLASH_URL')
+        if splash_url:
+            s['SPLASH_URL'] = splash_url
+    else:
+        s['SPLASH_URL'] = None
     return s
 
 

--- a/tests/test_spider.py
+++ b/tests/test_spider.py
@@ -3,6 +3,7 @@ import tempfile
 import pytest
 from twisted.web.resource import Resource
 
+from undercrawler.utils import using_splash
 from .utils import text_resource, html, paths_set, find_item, inlineCallbacks
 from .mockserver import MockServer
 from .conftest import make_crawler
@@ -67,7 +68,7 @@ class HHPage(text_resource(html(
 @inlineCallbacks
 def test_hh(settings):
     crawler = make_crawler(settings, AUTOLOGIN_ENABLED=False, RUN_HH=True)
-    if not crawler.settings.getbool('USE_SPLASH'):
+    if not using_splash(crawler.settings):
         pytest.skip('requires splash')
     with MockServer(HHPage) as s:
         root_url = s.root_url

--- a/undercrawler-arachnado/README.md
+++ b/undercrawler-arachnado/README.md
@@ -14,8 +14,7 @@ After that start everything with:
 
 Arachnado UI will be exposed at port 8888, and Autologin UI as 8088.
 
-In order to start the crawler, enter ``spider://uc``
-into the main "website URL" input in the Arachnado UI,
-set target URL via ``url`` spider argument
-(press a cog icon to the right of the url input to reveal arguments and settings),
-and pass settings as required (see main README for useful settings to tweak).
+In order to start the crawler, enter the url
+into the main "website URL" input in the Arachnado UI. If you want to tweak
+any settings (described in the top-level README),
+press a cog icon to the right of the url input.

--- a/undercrawler-arachnado/README.md
+++ b/undercrawler-arachnado/README.md
@@ -1,0 +1,15 @@
+Running undercrawler with arachnado and docker
+==============================================
+
+Currently, you need base "arachando" image built from
+https://github.com/TeamHG-Memex/arachnado.
+
+Next, build undercrawler-arachnado image:
+
+    docker build -t undercrawler-arachnado ..
+
+After that start everything with:
+
+    docker-compose up
+
+Arachnado UI will be exposed at port 8888, and Autologin UI as 8088.

--- a/undercrawler-arachnado/README.md
+++ b/undercrawler-arachnado/README.md
@@ -1,4 +1,4 @@
-Running undercrawler with arachnado and docker
+Running Undercrawler with Arachnado and Docker
 ==============================================
 
 Currently, you need base "arachando" image built from
@@ -13,3 +13,9 @@ After that start everything with:
     docker-compose up
 
 Arachnado UI will be exposed at port 8888, and Autologin UI as 8088.
+
+In order to start the crawler, enter ``spider://uc``
+into the main "website URL" input in the Arachnado UI,
+set target URL via ``url`` spider argument
+(press a cog icon to the right of the url input to reveal arguments and settings),
+and pass settings as required (see main README for useful settings to tweak).

--- a/undercrawler-arachnado/README.md
+++ b/undercrawler-arachnado/README.md
@@ -17,4 +17,14 @@ Arachnado UI will be exposed at port 8888, and Autologin UI as 8088.
 In order to start the crawler, enter the url
 into the main "website URL" input in the Arachnado UI. If you want to tweak
 any settings (described in the top-level README),
-press a cog icon to the right of the url input.
+press a cog icon to the right of the url input. Unlike starting crawls from
+the command line, default value for ``SPLASH_URL`` is ``None``
+(so the crawls will not use splash by default).
+
+There are some environment variables that will be passed to all crawls
+as default values for corresponding settings:
+``SPLASH_URL``, ``FILES_STORE``, ``AWS_ACCESS_KEY_ID``, ``AWS_SECRET_ACCESS_KEY``.
+For example, to run all crawls with splash by default, start the service
+in the following way:
+
+    SPLASH_URL=http://some-external-splash:8050 docker-compose up

--- a/undercrawler-arachnado/arachnado.conf
+++ b/undercrawler-arachnado/arachnado.conf
@@ -10,6 +10,8 @@ DISK_QUEUES_ROOT = /var/db/arachnado-jobs
 
 ; Packages to load spiders from (separated by whitespace)
 spider_packages = undercrawler.spiders
+; Default spider name
+default_spider_name = undercrawler_arachnado
 
 [arachnado.storage]
 ; it assumes there is a linked 'aracnhado-mongo' container

--- a/undercrawler-arachnado/arachnado.conf
+++ b/undercrawler-arachnado/arachnado.conf
@@ -1,5 +1,6 @@
 [arachnado]
 port = 8888
+loglevel = DEBUG
 
 [arachnado.scrapy]
 AUTOLOGIN_URL = http://autologin:8089

--- a/undercrawler-arachnado/arachnado.conf
+++ b/undercrawler-arachnado/arachnado.conf
@@ -1,0 +1,22 @@
+[arachnado]
+port = 8888
+
+[arachnado.scrapy]
+AUTOLOGIN_URL = http://autologin:8089
+
+; store jobs on a data volume
+DISK_QUEUES_ROOT = /var/db/arachnado-jobs
+
+; Packages to load spiders from (separated by whitespace)
+spider_packages = undercrawler.spiders
+
+[arachnado.storage]
+; it assumes there is a linked 'aracnhado-mongo' container
+items_uri = mongodb://arachnado-mongo:27017/arachnado/items
+items_uri_env = ITEMS_MONGO_URI
+
+jobs_uri = mongodb://arachnado-mongo:27017/arachnado/jobs
+jobs_uri_env = JOBS_MONGO_URI
+
+sites_uri = mongodb://arachnado-mongo:27017/arachnado/sites
+sites_uri_env = SITES_MONGO_URI

--- a/undercrawler-arachnado/docker-compose.yml
+++ b/undercrawler-arachnado/docker-compose.yml
@@ -1,0 +1,40 @@
+version: '2'
+
+services:
+    arachnado:
+        image: undercrawler-arachnado
+        expose:
+            - 8888
+        links:
+            - arachnado-mongo
+            - autologin
+        ports:
+            - "8888:8888"
+        volumes:
+            - ./arachnado.conf:/etc/arachnado.conf:ro
+            - arachnado-jobs:/var/db/arachnado-jobs
+
+    arachnado-mongo:
+        image: mongo
+        expose:
+            - 27017
+#       ports:
+#           - "27017:27017"
+        volumes:
+            - mongo-data:/data/db
+        restart: always
+
+    autologin:
+        image: hyperiongray/autologin:0.1.2
+        expose:
+            - 8088  # keychain UI
+            - 8089  # API
+        ports:
+            - "8088:8088"
+        volumes:
+            - autologin-data:/var/autologin
+
+volumes:
+    mongo-data: {}
+    autologin-data: {}
+    arachnado-jobs: {}

--- a/undercrawler-arachnado/docker-compose.yml
+++ b/undercrawler-arachnado/docker-compose.yml
@@ -3,6 +3,11 @@ version: '2'
 services:
     arachnado:
         image: undercrawler-arachnado
+        environment:
+            - SPLASH_URL
+            - FILES_STORE
+            - AWS_ACCESS_KEY_ID
+            - AWS_SECRET_ACCESS_KEY
         expose:
             - 8888
         links:

--- a/undercrawler/documents_pipeline.py
+++ b/undercrawler/documents_pipeline.py
@@ -7,7 +7,7 @@ from scrapy.pipelines.files import FilesPipeline, S3FilesStore, FSFilesStore
 from scrapy.exceptions import DropItem
 from scrapy_splash import SplashRequest, SlotPolicy
 
-from .utils import load_directive
+from .utils import load_directive, using_splash
 
 
 logging.getLogger('botocore').setLevel(logging.WARNING)
@@ -30,7 +30,7 @@ class CDRDocumentsPipeline(FilesPipeline):
                         '{} documents'.format(urlsplit(url).netloc),
                 },
             )
-            if self.crawler.settings.getbool('USE_SPLASH'):
+            if using_splash(self.crawler.settings):
                 request = SplashRequest(
                     endpoint='execute',
                     args={'lua_source': self.lua_source},

--- a/undercrawler/middleware/cookies.py
+++ b/undercrawler/middleware/cookies.py
@@ -5,6 +5,6 @@ from scrapy.exceptions import NotConfigured
 class CookiesMiddlewareIfNoSplash(ExposeCookiesMiddleware):
     @classmethod
     def from_crawler(cls, crawler):
-        if crawler.settings.getbool('USE_SPLASH'):
+        if crawler.settings.get('SPLASH_URL'):
             raise NotConfigured
         return super().from_crawler(crawler)

--- a/undercrawler/middleware/throttle.py
+++ b/undercrawler/middleware/throttle.py
@@ -17,9 +17,9 @@ class SplashAwareAutoThrottle(AutoThrottle):
         return cls(crawler)
 
     def process_request(self, request, spider):
-        if not hasattr(spider, 'download_delay'):
+        if not hasattr(self, 'mindelay'):
             self._spider_opened(spider)
-        assert hasattr(spider, 'download_delay')
+        assert hasattr(self, 'mindelay')
 
     def process_response(self, request, response, spider):
         if isinstance(response, SplashJsonResponse) and 'har' in response.data:

--- a/undercrawler/settings.py
+++ b/undercrawler/settings.py
@@ -15,8 +15,6 @@ CRAZY_SEARCH_ENABLED = True
 CDR_CRAWLER = 'scrapy undercrawler'
 CDR_TEAM = 'HG'
 
-USE_SPLASH = True
-
 PREFER_PAGINATION = True
 ADBLOCK = False
 MAX_DOMAIN_SEARCH_FORMS = 10
@@ -49,7 +47,7 @@ USER_AGENT = ('Mozilla/5.0 (X11; Linux i686) AppleWebKit/537.36 '
               '(KHTML, like Gecko) Ubuntu Chromium/43.0.2357.130 '
               'Chrome/43.0.2357.130 Safari/537.36')
 
-# enabled in CookiesMiddlewareIfNoSplash only when USE_SPLASH is False
+# enabled in CookiesMiddlewareIfNoSplash only when SPLASH_URL is set
 COOKIES_ENABLED = True
 
 # Run full headless-horseman scripts

--- a/undercrawler/spiders.py
+++ b/undercrawler/spiders.py
@@ -18,14 +18,14 @@ from scrapy.utils.python import unique
 from scrapy_splash import SplashRequest, SplashFormRequest
 from autologin_middleware import link_looks_like_logout
 
-from ..utils import cached_property
-from ..items import CDRItem
-from ..crazy_form_submitter import search_form_requests
-from ..utils import extract_text, load_directive
+from .utils import cached_property
+from .items import CDRItem
+from .crazy_form_submitter import search_form_requests
+from .utils import extract_text, load_directive
 
 
 class BaseSpider(scrapy.Spider):
-    name = 'base'
+    name = 'undercrawler'
 
     def __init__(self, url, search_terms=None, *args, **kwargs):
         if url.startswith('.'):

--- a/undercrawler/spiders.py
+++ b/undercrawler/spiders.py
@@ -298,7 +298,14 @@ class ArachnadoSpider(BaseSpider):
     custom_settings.setmodule(undercrawler.settings)
     custom_settings['ITEM_PIPELINES'][
         'arachnado.pipelines.mongoexport.MongoExportPipeline'] = 600
-    custom_settings['SPLASH_URL'] = None
+    custom_settings.update({
+        # Convenient to have defaults for all crawls
+        'SPLASH_URL': os.environ.get('SPLASH_URL'),
+        'FILES_STORE': os.environ.get('FILES_STORE'),
+        # Override some undesired Arachnado settings
+        'AUTOTHROTTLE_ENABLED': False,
+        'DOWNLOAD_MAXSIZE': None,
+    })
 
     def __init__(self, *, domain, crawl_id):
         self.crawl_id = crawl_id

--- a/undercrawler/spiders.py
+++ b/undercrawler/spiders.py
@@ -21,7 +21,7 @@ from autologin_middleware import link_looks_like_logout
 
 from .crazy_form_submitter import search_form_requests
 from .items import CDRItem
-from .utils import cached_property, extract_text, load_directive
+from .utils import cached_property, extract_text, load_directive, using_splash
 import undercrawler.settings
 
 
@@ -49,7 +49,7 @@ class BaseSpider(scrapy.Spider):
         super().__init__(*args, **kwargs)
 
     def start_requests(self):
-        self.use_splash = self.settings.getbool('USE_SPLASH')
+        self.use_splash = using_splash(self.settings)
         for url in self.start_urls:
             yield self.make_request(url, callback=self.parse_first)
 

--- a/undercrawler/spiders.py
+++ b/undercrawler/spiders.py
@@ -13,15 +13,16 @@ import formasaurus
 import scrapy
 from scrapy import Request, FormRequest
 from scrapy.linkextractors import LinkExtractor
+from scrapy.settings import Settings
 from scrapy.utils.url import canonicalize_url, add_http_if_no_scheme
 from scrapy.utils.python import unique
 from scrapy_splash import SplashRequest, SplashFormRequest
 from autologin_middleware import link_looks_like_logout
 
-from .utils import cached_property
-from .items import CDRItem
 from .crazy_form_submitter import search_form_requests
-from .utils import extract_text, load_directive
+from .items import CDRItem
+from .utils import cached_property, extract_text, load_directive
+import undercrawler.settings
 
 
 class BaseSpider(scrapy.Spider):
@@ -289,6 +290,14 @@ class BaseSpider(scrapy.Spider):
         with open(filename, 'wb') as f:
             f.write(b64decode(screenshot))
         self.logger.debug('Saved %s screenshot to %s' % (response, filename))
+
+
+class ArachnadoSpider(BaseSpider):
+    name = 'uc'
+    custom_settings = Settings()
+    custom_settings.setmodule(undercrawler.settings)
+    custom_settings['ITEM_PIPELINES'][
+        'arachnado.pipelines.mongoexport.MongoExportPipeline'] = 600
 
 
 @contextlib.contextmanager

--- a/undercrawler/spiders.py
+++ b/undercrawler/spiders.py
@@ -293,11 +293,18 @@ class BaseSpider(scrapy.Spider):
 
 
 class ArachnadoSpider(BaseSpider):
-    name = 'uc'
+    name = 'undercrawler_arachnado'
     custom_settings = Settings()
     custom_settings.setmodule(undercrawler.settings)
     custom_settings['ITEM_PIPELINES'][
         'arachnado.pipelines.mongoexport.MongoExportPipeline'] = 600
+    custom_settings['SPLASH_URL'] = None
+
+    def __init__(self, *, domain, crawl_id):
+        self.crawl_id = crawl_id
+        self.domain = domain
+        super().__init__(url=domain)
+        self.start_url = self.start_urls[0]
 
 
 @contextlib.contextmanager

--- a/undercrawler/spiders/__init__.py
+++ b/undercrawler/spiders/__init__.py
@@ -1,1 +1,0 @@
-from .base_spider import BaseSpider

--- a/undercrawler/utils.py
+++ b/undercrawler/utils.py
@@ -21,3 +21,7 @@ def load_directive(filename):
     root = os.path.join(os.path.dirname(__file__), 'directives')
     with open(os.path.join(root, filename)) as f:
         return f.read()
+
+
+def using_splash(settings):
+    return bool(settings.get('SPLASH_URL'))


### PR DESCRIPTION
Also rename spider to "undercrawler" and make spiders module a single file.

TODO:
- [x] ~~Fix the name of the base arachnado image: it's "arachnado" right now, should by "hyperiongray/arachnado"?~~ will use arachnado for now
- [x] Check that everything is running as expected: not sure how it runs without splash now, it should fail? ~~Also autologin url is probably not passed correctly.~~
- [x] What do we do with splash? Either disable it by default, ~~or bundle it with Tor support?~~
- [x] Make undercrawler the default crawler for better UX
- [x] Review resulting settings - could there be some undesired options in arachnado settings we want to override (like `DOWNLOAD_MAXSIZE`)?
