### PR TITLE
[WIP] More screenshot options, save screenshot path to item metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,20 +100,34 @@ Useful options to tweak (add to the above command via ``-s NAME=value``):
 - ``CDR_CRAWLER``, ``CDR_TEAM`` - CDR export metadata constants
 - ``CRAZY_SEARCH_ENABLED`` - set to 0 to disable submitting search forms
 - ``DOWNLOAD_DELAY`` - set to 0 when crawling local test server
-- ``FILES_STORE`` - S3 location for saving extracted documents
-  (format is ``s3://bucket/prefix/``)
+- ``FILES_STORE`` - S3 location for saving extracted documents (including images),
+  format is ``s3://bucket/prefix/``.
 - ``FORCE_TOR`` - crawl via tor to avoid blocking
 - ``HARD_URL_CONSTRAINT`` - set to 1 to treat start urls as hard constraints
   (by default we start from given url but crawl the whole domain)
+- ``IMAGES_ENABLED`` - set to 1 to enable loading images in splash.
+  This affects only the screenshots (and speed), but not saving images.
 - ``MAX_DOMAIN_SEARCH_FORMS`` - max number of search forms considered for domain
 - ``PREFER_PAGINATION`` - set to 0 to disable pagination handling, or adjust
   as needed (value is in seconds).
-- ``RUN_HH`` - set to 0 to skip running full headless-horesman scripts
+- ``RUN_HH`` - set to 0 to skip running full headless-horseman scripts.
 - ``SEARCH_TERMS_FILE`` - file with extra search terms to use (one per line)
-- ``SCREENSHOTS`` - set to 1 to save screenshots while crawling (make sure
-  you do not change the logging level from default ``DEBUG``).
+- ``SCREENSHOT`` - set to 1 to save screenshots while crawling. Path to screenshot
+   will be saved to ``screenshot`` field in the item metadata. It's relative by
+   default, but will be absolute if you pass absolute path to ``SCREENSHOT_DEST``.
+- ``SCREENSHOT_DEST`` - set path to folder where to store the screenshots
+   ("screenshots" by default).
+- ``SCREENSHOT_WIDTH``, ``SCREENSHOT_HEIGHT``: screenshot size.
+   If ``SCREENSHOT_HEIGHT`` is set to 0, then the full page height is used for the
+   screenshot. If not set, screenshot dimensions are equal to
+ ``VIEWPORT_WIDTH`` and ``VIEWPORT_HEIGHT``.
+- ``SCREENSHOT_PREFIX`` - set prefix for screenshot files, empty by default.
 - ``SPLASH_URL`` - url of the splash instance
   (if empty, crawl without using splash)
+- ``VIEWPORT_WIDTH``, ``VIEWPORT_HEIGHT``: viewport size for splash rendering.
+  Note that these settings can affect resulting content, as
+  many websites use a mobile version for smaller screens.
+  Defaults are 1024 and 768.
 
 Pages are stored in CDRv2 format, with the following custom fields inside
 ``extracted_metadata``:
@@ -126,6 +140,7 @@ Pages are stored in CDRv2 format, with the following custom fields inside
 - ``is_onclick``: page url was extracted from ``onclick``, not from a normal link
 - ``is_page``: page was reached via pagination
 - ``is_search``: this is a search result page
+- ``screenshot``: path to saved screenshot, if any (see ``SCREENSHOT`` setting)
 
 All documents (including images) are exported if ``FILES_STORE`` is set.
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,11 @@
-scrapy==1.1.0
-botocore
-scrapy-splash==0.6
 autologin-middleware
-MaybeDont
-Formasaurus[with_deps]>=0.8
 autopager==0.2
+botocore
 datasketch==0.2.3
-tqdm
+Formasaurus[with_deps]>=0.8
+MaybeDont
 pytest
+scrapy-splash==0.6
+scrapy==1.1.0
+tqdm
+typing

--- a/setup.py
+++ b/setup.py
@@ -5,12 +5,13 @@ setup(
     name='undercrawler',
     packages=['undercrawler'],
     install_requires=[
-        'scrapy>=1.1.0',
-        'botocore',
-        'scrapy-splash>=0.6',
         'autologin-middleware',
-        'MaybeDont',
-        'Formasaurus[with_deps]>=0.8',
         'autopager>=0.2',
+        'botocore',
+        'Formasaurus[with_deps]>=0.8',
+        'MaybeDont',
+        'scrapy-splash>=0.6',
+        'scrapy>=1.1.0',
+        'typing',
     ],
 )

--- a/undercrawler/directives/headless_horseman.lua
+++ b/undercrawler/directives/headless_horseman.lua
@@ -25,11 +25,12 @@ function main(splash)
   local cookies = get_arg(splash.args.cookies, nil)
   local visual = get_arg(splash.args.visual, false)
 
-  -- 992px is Bootstrap's minimum "desktop" size. 744 gives the viewport
-  -- a nice 4:3 aspect ratio. We may need to tweak the viewport size even
-  -- higher, based on real world usage...
-  local viewport_width = splash.args.viewport_width or 992
-  local viewport_height = splash.args.viewport_height or 744
+  -- 1024px is already "desktop" size for most frameworks,
+  -- and 768 gives 4:3 aspect ratio.
+  local viewport_width = get_arg(splash.args.viewport_width, 1024)
+  local viewport_height = get_arg(splash.args.viewport_height, 768)
+  local screenshot_width = get_arg(splash.args.screenshot_width, viewport_width)
+  local screenshot_height = get_arg(splash.args.screenshot_height, viewport_height)
 
   splash.images_enabled = get_arg(splash.args.images_enabled, true)
   -- Set different timeouts for the first and for other requests
@@ -80,11 +81,11 @@ function main(splash)
           .then(splash.resume);
       }
     ]])
-
-    splash:stop()
-    splash:set_viewport_full()
-    splash:wait(1)
   end
+
+  splash:stop()
+  splash:set_viewport_full()
+  splash:wait(1)
 
   -- Render and return the requested outputs.
 
@@ -101,7 +102,11 @@ function main(splash)
   end
 
   if return_png then
-    render['png'] = splash:png{width=viewport_width}
+    if screenshot_height == 0 then
+      render['png'] = splash:png{width=screenshot_width}
+    else
+      render['png'] = splash:png{width=screenshot_width, height=screenshot_height}
+    end
   end
 
   render['url'] = splash:url()

--- a/undercrawler/settings.py
+++ b/undercrawler/settings.py
@@ -68,14 +68,12 @@ LOG_UNSERIALIZABLE_REQUESTS = True
 
 RETRY_ENABLED = True
 
+TELNETCONSOLE_ENABLED = False
 
 # Unused settings from template
 
 # Configure maximum concurrent requests performed by Scrapy (default: 16)
 #CONCURRENT_REQUESTS = 32
-
-# Disable Telnet Console (enabled by default)
-#TELNETCONSOLE_ENABLED = False
 
 # Override the default request headers:
 #DEFAULT_REQUEST_HEADERS = {


### PR DESCRIPTION
New settings:
- ``IMAGES_ENABLED`` - set to 1 to enable loading images in splash.
  This affects only the screenshots (and speed), but not saving images.
- ``SCREENSHOT`` - set to 1 to save screenshots while crawling. Path to screenshot
   will be saved to ``screenshot`` field in the item metadata. It's relative by
   default, but will be absolute if you pass absolute path to ``SCREENSHOT_DEST``.
- ``SCREENSHOT_DEST`` - set path to folder where to store the screenshots
   ("screenshots" by default).
- ``SCREENSHOT_WIDTH``, ``SCREENSHOT_HEIGHT``: screenshot size.
   If ``SCREENSHOT_HEIGHT`` is set to 0, then the full page height is used for the
   screenshot. If not set, screenshot dimensions are equal to
 ``VIEWPORT_WIDTH`` and ``VIEWPORT_HEIGHT``.
- ``SCREENSHOT_PREFIX`` - set prefix for screenshot files, empty by default.
- ``VIEWPORT_WIDTH``, ``VIEWPORT_HEIGHT``: viewport size for splash rendering.
  Note that these settings can affect resulting content, as
  many websites use a mobile version for smaller screens.
  Defaults are 1024 and 768.