### PR TITLE
Add FOLLOW_LINKS option

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,13 +170,8 @@ Run all tests with:
 
     tox
 
-This assumes that splash is running on the default url http://127.0.0.1:8050,
-you can pass it to tests like this (required on OS X with splash in docker):
-
-    SPLASH_URL=http://192.168.99.100:8050 tox
-
-Note that you can not use an external splash instance, because tests start
-local test servers.
+This assumes that splash is running on the default url http://127.0.0.1:8050
+with ``--network host``.
 
 Tests are run using py.test, you can pass arguments after ``--``:
 

--- a/README.md
+++ b/README.md
@@ -109,6 +109,8 @@ Useful options to tweak (add to the above command via ``-s NAME=value``):
   format is ``s3://bucket/prefix/`` for storing to S3 or a local path for storing
   media items locally (in case of local path, ``obj_stored_url`` will be relative
   to the ``FILES_STORE`` path).
+- ``FOLLOW_LINKS`` - set to 0 to crawl only initial urls. Media items will still
+  be crawled (if they should be crawled according to the rest of the settings)
 - ``FORCE_TOR`` - crawl via tor to avoid blocking
 - ``HARD_URL_CONSTRAINT`` - set to 1 to treat start urls as hard constraints
   (by default we start from given url but crawl the whole domain)

--- a/README.md
+++ b/README.md
@@ -86,8 +86,9 @@ Specify url to crawl via the ``url`` param, and run the ``undercrawler`` spider:
 
     scrapy crawl undercrawler -a url=http://127.0.0.1:8001
 
-You can also specify a file to read urls from, with ``-a url=./urls.txt``,
-but in this case you must ensure that all urls use common authentication
+You can also specify a file to read urls from, with ``-a url=./urls.txt``
+(this can be an absolute path starting with "/" or a relative path starting with ".").
+In case of multiple urls you must ensure that all urls use common authentication
 (e.g. are from the same domain), or disable autologin.
 
 Useful options to tweak (add to the above command via ``-s NAME=value``):

--- a/undercrawler/settings.py
+++ b/undercrawler/settings.py
@@ -11,6 +11,7 @@ SPLASH_URL = 'http://127.0.0.1:8050'
 AUTOLOGIN_URL = 'http://127.0.0.1:8089'
 AUTOLOGIN_ENABLED = True
 CRAZY_SEARCH_ENABLED = True
+FOLLOW_LINKS = True
 
 CDR_CRAWLER = 'scrapy undercrawler'
 CDR_TEAM = 'HG'

--- a/undercrawler/spiders.py
+++ b/undercrawler/spiders.py
@@ -1,4 +1,5 @@
 from base64 import b64decode
+import codecs
 import contextlib
 import hashlib
 import os
@@ -29,7 +30,7 @@ class BaseSpider(scrapy.Spider):
 
     def __init__(self, url, search_terms=None, *args, **kwargs):
         if url.startswith('.'):
-            with open(url) as f:
+            with codecs.open(url, 'r', encoding='utf8') as f:
                 urls = [line.strip() for line in f]
         else:
             urls = [url]
@@ -213,7 +214,7 @@ class BaseSpider(scrapy.Spider):
     def extra_search_terms(self):
         st_file = self.settings.get('SEARCH_TERMS_FILE')
         if st_file:
-            with open(st_file) as f:
+            with codecs.open(st_file, 'r', encoding='utf8') as f:
                 return [line.strip() for line in f]
         else:
             return []

--- a/undercrawler/spiders.py
+++ b/undercrawler/spiders.py
@@ -128,6 +128,9 @@ class BaseSpider(scrapy.Spider):
         yield self.text_cdr_item(
             response, follow_urls=follow_urls, metadata=metadata)
 
+        if not self.settings.getbool('FOLLOW_LINKS'):
+            return
+
         if self.settings.getbool('PREFER_PAGINATION'):
             # Follow pagination links; pagination is not a subject of
             # a max depth limit. This also prioritizes pagination links because

--- a/undercrawler/spiders.py
+++ b/undercrawler/spiders.py
@@ -21,7 +21,7 @@ from scrapy_splash import SplashRequest, SplashFormRequest
 from autologin_middleware import link_looks_like_logout
 
 from .crazy_form_submitter import search_form_requests
-from .utils import cached_property, extract_text, load_directive, using_splash
+from .utils import cached_property, load_directive, using_splash
 import undercrawler.settings
 
 

--- a/undercrawler/spiders.py
+++ b/undercrawler/spiders.py
@@ -29,7 +29,7 @@ class BaseSpider(scrapy.Spider):
     name = 'undercrawler'
 
     def __init__(self, url, search_terms=None, *args, **kwargs):
-        if url.startswith('.'):
+        if url.startswith('.') or url.startswith('/'):
             with codecs.open(url, 'r', encoding='utf8') as f:
                 urls = [line.strip() for line in f]
         else:

--- a/undercrawler/utils.py
+++ b/undercrawler/utils.py
@@ -13,10 +13,6 @@ def cached_property(name):
     return deco
 
 
-def extract_text(response):
-    return '\n'.join(response.xpath('//body').xpath('string()').extract())
-
-
 def load_directive(filename):
     root = os.path.join(os.path.dirname(__file__), 'directives')
     with open(os.path.join(root, filename)) as f:


### PR DESCRIPTION
It allows to crawl a single page (or a list of pages) without following any links. Media items are downloaded (or not downloaded) regardless of this setting.

Also allow ``urls`` argument to be an absolute path too, make allowed regexp construction more efficient, and always read files with utf8 encoding.